### PR TITLE
Flush test names to allow printf IO in unit under test

### DIFF
--- a/cxxtest/cxxtest/VerboseListener.h
+++ b/cxxtest/cxxtest/VerboseListener.h
@@ -11,14 +11,17 @@ namespace CxxTest
         void enterWorld( const WorldDescription & desc )
 		{
 			* outputStream() << "\nCOUNT " << desc.numTotalTests() << "\n";
+			outputStream()->flush();
 		}
         void enterSuite( const SuiteDescription & desc )
 		{
 			* outputStream() << "\nSUITE '" << desc.suiteName() << "'\n";
+			outputStream()->flush();
 		}
         void enterTest( const TestDescription & desc )
 		{
 			* outputStream() << "\nTEST '" << desc.testName() << "'\n";
+			outputStream()->flush();
 		}
         void leaveWorld( const WorldDescription &desc ) {}
         void leaveTest( const TestDescription & ) {}


### PR DESCRIPTION
This commit flushes test names printed by VerboseListener.
This is because if not flushed, the output of the process may be
corrupted if unit under test uses printf-like output, instead of ostream.