### PR TITLE
Using Voodoo-Mock on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,25 @@ all: build unittest
 build: build_examples
 clean: clean_examples
 
+ifdef SystemRoot
+# Windows system
+SET_ENV_VAR=& set PYTHONPATH=%PYTHONPATH%;. & set LD_LIBRARY_PATH=%LD_LIBRARY_PATH%;. &
+MAKE_EXAMPLE_2=make -C examples/2_feature_full_project_scaffold__copy_me
+else
+#Non-winsodw system
+SET_ENV_VAR=; PYTHONPATH=. LD_LIBRARY_PATH=.
+MAKE_EXAMPLE_2=cd examples/2_feature_full_project_scaffold__copy_me; ./env make
+endif
+
 unittest: unittest_c unittest_cpp
 unittest_c:
-	cd voodoo; PYTHONPATH=. LD_LIBRARY_PATH=. python unittests/test_c_parsing.py
+	cd voodoo $(SET_ENV_VAR) python unittests/test_c_parsing.py
 unittest_cpp:
-	cd voodoo; PYTHONPATH=. LD_LIBRARY_PATH=. python unittests/test_cpp_parsing.py
+	cd voodoo $(SET_ENV_VAR) python unittests/test_cpp_parsing.py
 
 clean_examples:
 	make -C examples/1_simplest_project clean
-	cd examples/2_feature_full_project_scaffold__copy_me; ./env make clean
+	$(MAKE_EXAMPLE_2) clean
 	make -C examples/3_writing_cpp_tests/mocking_template_methods clean
 	make -C examples/3_writing_cpp_tests/mocking_template_classes clean
 	make -C examples/3_writing_cpp_tests/custom_stubs clean
@@ -21,7 +31,7 @@ clean_examples:
 
 build_examples:
 	make -C examples/1_simplest_project
-	cd examples/2_feature_full_project_scaffold__copy_me; ./env make
+	$(MAKE_EXAMPLE_2)
 	make -C examples/3_writing_cpp_tests/mocking_template_methods
 	make -C examples/3_writing_cpp_tests/mocking_template_classes
 	make -C examples/3_writing_cpp_tests/custom_stubs

--- a/cxxtest/VoodooConfiguration.h
+++ b/cxxtest/VoodooConfiguration.h
@@ -1,6 +1,6 @@
 #include <cxxtest/TestSuite.h>
 
-#ifdef __GNUC__
+#if !defined( _WIN32 ) && defined( __GNUG__ )
 
 #include <execinfo.h>
 

--- a/cxxtest/cxxtest/PrintStack.h
+++ b/cxxtest/cxxtest/PrintStack.h
@@ -1,7 +1,7 @@
 #ifndef __CXXTEST_PRINT_STACK_H__
 #define __CXXTEST_PRINT_STACK_H__
 
-#if ( __GNUG__ )
+#if !defined( _WIN32 ) && defined( __GNUG__ )
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/1_simplest_project/Makefile
+++ b/examples/1_simplest_project/Makefile
@@ -1,6 +1,9 @@
+export ENFORCE_COVERAGE_FIND_ROOT_CPP = .
+include $(VOODOO_ROOT_DIR)/make/common.Makefile
+
 all: test
 
-export VOODOO_ROOT_DIR = ../..
+#export VOODOO_ROOT_DIR = ../..
 
 clean:
 	rm -fr build_unittest build
@@ -14,5 +17,5 @@ test: buildall
 buildall: build/main
 
 build/main: main.cpp File.h Map.h
-	-mkdir $(@D)
-	g++ -o $@ $< -Wall
+	@$(call MKDIR,$(@D))
+	@g++ -o $@ $< -Wall

--- a/examples/2_feature_full_project_scaffold__copy_me/tools/make/Makefile
+++ b/examples/2_feature_full_project_scaffold__copy_me/tools/make/Makefile
@@ -1,3 +1,9 @@
+ifdef SystemRoot
+#SHELL
+else
+SHELL := /bin/bash
+endif
+
 all: all-targets
 
 ifeq ($(V),1)
@@ -15,7 +21,6 @@ mapexample_LIBRARIES = -lpthread
 #Namespace_object2_o_CFLAGS = -fPIC -DPIC
 
 CONFIGURATION ?= DEBUG
-SHELL := /bin/bash
 COMMON_CXXFLAGS = -Ic -Icpp -I/usr/include/python2.7 -std=gnu++0x -Werror -Wall
 DEBUG_CXXFLAGS = -ggdb -DDEBUG
 RELEASE_CXXFLAGS = -O3
@@ -25,4 +30,5 @@ RELEASE_CFLAGS = $(RELEASE_CXXFLAGS)
 CXXFLAGS = $(COMMON_CXXFLAGS) $($(CONFIGURATION)_CXXFLAGS)
 CFLAGS = $(COMMON_CFLAGS) $($(CONFIGURATION)_CFLAGS)
 
+include $(VOODOO_ROOT_DIR)/make/common.Makefile
 include tools/make/rules.Makefile

--- a/examples/2_feature_full_project_scaffold__copy_me/tools/make/rules.Makefile
+++ b/examples/2_feature_full_project_scaffold__copy_me/tools/make/rules.Makefile
@@ -40,31 +40,31 @@ $(foreach target,$(filter SHAREDLIBRARY_%, $(.VARIABLES)), \
 )
 
 build/cpp/%.o: cpp/%.cpp
-	@mkdir -p $(@D)
+	$(Q)$(call MKDIR, $(@D))
 	@echo 'C++     ' $@
 	$(Q)g++ $(CXXFLAGS) $($(subst /,_,$(subst .,_,$*))_o_CFLAGS) -MMD -MF $@.deps -c $< -o $@
 
 build/c/%.o: c/%.c
-	@mkdir -p $(@D)
+	$(Q)$(call MKDIR, $(@D))
 	@echo 'C       ' $@
 	$(Q)gcc $(CFLAGS) $($(subst /,_,$(subst .,_,$*))_o_CFLAGS) -MMD -MF $@.deps -c $< -o $@
 
 build/cpp/%.bin:
-	@mkdir -p $(@D)
+	$(Q)$(call MKDIR, $(@D))
 	@echo 'LINK++  ' $@
 	$(Q)g++ $(LDFLAGS) -o $@ $^ $($*_LDFLAGS) $($*_LIBRARIES)
 
 build/c/%.bin:
-	@mkdir -p $(@D)
+	$(Q)$(call MKDIR, $(@D))
 	@echo 'LINK    ' $@
 	$(Q)gcc $(LDFLAGS) -o $@ $^ $($*_LDFLAGS) $($*_LIBRARIES)
 
 build/cpp/%.so:
-	@mkdir -p $(@D)
+	$(Q)$(call MKDIR, $(@D))
 	@echo 'LINK++  ' $@
 	$(Q)g++ -shared $(LDFLAGS) -o $@ $^ $($*_LDFLAGS) $($*_LIBRARIES)
 
 build/c/%.so:
-	@mkdir -p $(@D)
+	$(Q)$(call MKDIR, $(@D))
 	@echo 'LINK    ' $@
 	$(Q)gcc -shared $(LDFLAGS) -o $@ $^ $($*_LDFLAGS) $($*_LIBRARIES)

--- a/examples/6_coverage_enforcement/Makefile
+++ b/examples/6_coverage_enforcement/Makefile
@@ -1,11 +1,13 @@
+include $(VOODOO_ROOT_DIR)/make/common.Makefile
+
 all: 
-	( make -f undertest.Makefile 2>&1 || true ) | grep 'cpp/FileNotCovered.h:1: COVERAGE ERROR: file is not covered by unit test'
-	( make -f undertest.Makefile 2>&1 || true ) | grep 'cpp/ToCover.h:21: COVERAGE ERROR: line is not covered by unit test'
-	( make -f undertest.Makefile 2>&1 || true ) | grep 'cpp/ToCover.h:32: COVERAGE ERROR: line is not covered by unit test'
-	( make -f undertest.Makefile 2>&1 || true ) | grep 'cpp/ToCover.h:33: COVERAGE ERROR: line is not covered by unit test'
-	( make -f undertest.Makefile 2>&1 || true ) | grep 'cpp/ToCover.h:19: COVERAGE_WARNING: non code line marked as exempt'
-	test `( make -f undertest.Makefile 2>&1 || true ) | grep COVERAGE.ERROR | wc -l` -eq 4
-	test `( make -f undertest.Makefile 2>&1 || true ) | grep COVERAGE.WARNING | wc -l` -eq 1
+	@( make -f undertest.Makefile 2>&1 || true ) | grep "cpp$(DIR_SEP)FileNotCovered.h:1: COVERAGE ERROR: file is not covered by unit test"
+	@( make -f undertest.Makefile 2>&1 || true ) | grep "cpp$(DIR_SEP)ToCover.h:21: COVERAGE ERROR: line is not covered by unit test"
+	@( make -f undertest.Makefile 2>&1 || true ) | grep "cpp$(DIR_SEP)ToCover.h:32: COVERAGE ERROR: line is not covered by unit test"
+	@( make -f undertest.Makefile 2>&1 || true ) | grep "cpp$(DIR_SEP)ToCover.h:33: COVERAGE ERROR: line is not covered by unit test"
+	@( make -f undertest.Makefile 2>&1 || true ) | grep "cpp$(DIR_SEP)ToCover.h:19: COVERAGE_WARNING: non code line marked as exempt"
+	test $(shell (make -f undertest.Makefile 2>&1 || true ) | grep COVERAGE.ERROR | wc -l) -eq 4
+	test $(shell (make -f undertest.Makefile 2>&1 || true ) | grep COVERAGE.WARNING | wc -l) -eq 1
 
 clean:
 	rm -fr build_unittest

--- a/make/2_build.Makefile
+++ b/make/2_build.Makefile
@@ -5,7 +5,11 @@ include $(VOODOO_ROOT_DIR)/make/common.Makefile
 UNITTEST_CXXFLAGS ?= -DDEBUG -DUNITTEST
 UNITTEST_INCLUDES ?= -I.
 UNITTEST_LDFLAGS ?=
+ifdef SystemRoot
+UNITTEST_LIBS ?= 
+else
 UNITTEST_LIBS ?= -ldl
+endif
 
 UNITTEST_CXXFLAGS += -std=gnu++0x -Werror -Wall -ggdb -DDEBUG -DUNITTEST --coverage
 UNITTEST_LDFLAGS += --coverage

--- a/make/3_run.Makefile
+++ b/make/3_run.Makefile
@@ -7,5 +7,5 @@ PYTEST_TEST_FILES = $(shell find $(PYTEST_FIND_PATTERN) $(__REMOVE_DOT_SLASH_PRE
 
 runAllTests:
 	$(Q)echo "Running all tests"
-	$(Q)rm -fr .coverage*
+	$(Q)$(call RM_RECURSIVE,.coverage*)
 	$(Q)python $(VOODOO_ROOT_DIR)/pytest/pytestharness.py $(PYTESTHARNESS_FLAGS) $(CXXTEST_BINARIES) $(PYTEST_TEST_FILES)

--- a/make/4_optional_enforce_cpp_coverage.Makefile
+++ b/make/4_optional_enforce_cpp_coverage.Makefile
@@ -2,7 +2,9 @@ enforceCPPCoverage: runEnforcement
 
 include $(VOODOO_ROOT_DIR)/make/common.Makefile
 
-ENFORCE_COVERAGE_CPP_SOURCE_FILES = $(shell find $(ENFORCE_COVERAGE_FIND_PATTERN_CPP) $(__REMOVE_DOT_SLASH_PREFIX))
+ENFORCE_COVERAGE_CPP_SOURCE_FILES  := $(shell find $(ENFORCE_COVERAGE_FIND_PATTERN_CPP) $(__REMOVE_DOT_SLASH_PREFIX))
 
 runEnforcement:
-	$(Q)python $(VOODOO_ROOT_DIR)/make/enforce_cpp_coverage.py $(CXXTEST_BINARIES) --enforceOn $(ENFORCE_COVERAGE_CPP_SOURCE_FILES)
+	@echo $(ENFORCE_COVERAGE_FIND_PATTERN_CPP)
+	@echo $(ENFORCE_COVERAGE_CPP_SOURCE_FILES)
+	$(Q)python $(VOODOO_ROOT_DIR)/make/enforce_cpp_coverage.py $(CXXTEST_BINARIES) --enforceOn $(call FixPath,$(ENFORCE_COVERAGE_CPP_SOURCE_FILES))

--- a/make/common.Makefile
+++ b/make/common.Makefile
@@ -1,19 +1,38 @@
+ifdef SystemRoot
+  FixPath = $(subst /,\,$1)
+  MKDIR = if not exist $1 mkdir $(call FixPath, $1)
+  RM = del /Q
+  RM_RECURSIVE = if exist $1 (rd /S /Q $1)
+  DIR_SEP = \\
+  	
+else
+  FixPath = $1
+  MKDIR = mkdir --parents $1
+  RM = rm -f
+  RM_RECURSIVE = rm -rf $1
+  DIR_SEP = /
+endif
+
 UNITTEST_BUILD_DIRECTORY ?= build_unittest
 CXXTEST_FIND_ROOT ?=
-CXXTEST_FIND_PATTERN ?= $(CXXTEST_FIND_ROOT) -name 'Test_*.h'
+CXXTEST_FIND_PATTERN ?= $(CXXTEST_FIND_ROOT) -iname Test_*.h
 PYTEST_FIND_ROOT ?=
-PYTEST_FIND_PATTERN ?= $(PYTEST_FIND_ROOT) -name 'test_*.py'
+PYTEST_FIND_PATTERN ?= $(PYTEST_FIND_ROOT) -iname test_*.py
 ENFORCE_COVERAGE_FIND_ROOT_CPP ?=
-ENFORCE_COVERAGE_FIND_EXCLUDE_REGEXES ?= '.*\<$(UNITTEST_BUILD_DIRECTORY)\>/.*' '.*\<tests\>.*' '.*\<build\>.*'
-ENFORCE_COVERAGE_FIND_PATTERN_CPP ?= $(ENFORCE_COVERAGE_FIND_ROOT_CPP) '(' -name '*.cpp' -or -name '*.h' ')' $(patsubst %,-and -not -regex %,$(ENFORCE_COVERAGE_FIND_EXCLUDE_REGEXES))
+ENFORCE_COVERAGE_FIND_EXCLUDE_REGEXES ?= ".*\<$(UNITTEST_BUILD_DIRECTORY)\>.*" ".*\<tests\>.*" ".*\<build\>.*"
+ifdef SystemRoot
+ENFORCE_COVERAGE_FIND_PATTERN_CPP ?= $(ENFORCE_COVERAGE_FIND_ROOT_CPP) "(" -iname *\.cpp -or -iname *\.h ")" $(patsubst %,-and -not -regex %,$(ENFORCE_COVERAGE_FIND_EXCLUDE_REGEXES))
+else
+ENFORCE_COVERAGE_FIND_PATTERN_CPP ?= $(ENFORCE_COVERAGE_FIND_ROOT_CPP) "(" -name "*.cpp" -or -name "*.h" ")" $(patsubst %,-and -not -regex %,$(ENFORCE_COVERAGE_FIND_EXCLUDE_REGEXES))
+endif
 
-VOODOO_MIRROR_TREE ?= $(UNITTEST_BUILD_DIRECTORY)/voodoo
+VOODOO_MIRROR_TREE ?= $(call FixPath,$(UNITTEST_BUILD_DIRECTORY)/voodoo)
 
-__REMOVE_DOT_SLASH_PREFIX = | sed 's@^\./@@'
+__REMOVE_DOT_SLASH_PREFIX = | sed "s@^\./@@"
 __POSSIBLE_UNITTEST_SUFFIXES = .h .H .hh .HH .hxx .HXX .hpp .HPP
 CXXTEST_TEST_FILES = $(shell find $(CXXTEST_FIND_PATTERN) $(__REMOVE_DOT_SLASH_PREFIX))
-CXXTEST_GENERATED = $(filter %.cxx,$(foreach suffix,$(__POSSIBLE_UNITTEST_SUFFIXES),$(patsubst %$(suffix),$(UNITTEST_BUILD_DIRECTORY)/%.cxx,$(subst /,_,$(CXXTEST_TEST_FILES)))))
-CXXTEST_BINARIES = $(patsubst %.cxx,%.bin,$(CXXTEST_GENERATED))
+CXXTEST_GENERATED = $(call FixPath,$(filter %.cxx,$(foreach suffix,$(__POSSIBLE_UNITTEST_SUFFIXES),$(patsubst %$(suffix),$(UNITTEST_BUILD_DIRECTORY)/%.cxx,$(subst /,_,$(CXXTEST_TEST_FILES))))))
+CXXTEST_BINARIES = $(call FixPath,$(patsubst %.cxx,%.bin,$(CXXTEST_GENERATED)))
 
 ifeq ($(V),1)
   Q =

--- a/pytest/pytestharness.py
+++ b/pytest/pytestharness.py
@@ -8,7 +8,7 @@ import getopt
 import threading
 import pickle
 import time
-import pwd
+# import pwd
 import json
 import argparse
 

--- a/voodoo/emulate_gcc_in_clang_preinclude.h
+++ b/voodoo/emulate_gcc_in_clang_preinclude.h
@@ -15,8 +15,8 @@ typedef int __v4si __attribute__ ((__vector_size__ (16)));
 
 
 int __builtin_ia32_bsrsi( int ) { return 0; }
-int __builtin_ia32_rdpmc( int ) { return 0; }
-unsigned long long __builtin_ia32_rdtsc() { return 0; }
+// unsigned long long __builtin_ia32_rdpmc( int ) { return 0; }
+// unsigned long long __builtin_ia32_rdtsc() { return 0; }
 unsigned long long __builtin_ia32_rdtscp( void * ) { return 0; }
 unsigned char __builtin_ia32_rolqi(unsigned char __X, int __C) { return '\0'; }
 unsigned short __builtin_ia32_rolhi (unsigned short __X, int __C) { return 0; }
@@ -26,14 +26,14 @@ unsigned short __builtin_ia32_rorhi(unsigned short __X, int __C) { return 0; }
 void __builtin_ia32_pause( void ) {}
 int __builtin_ia32_bsrdi( long long ) { return 0; }
 __m128 __builtin_ia32_addss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpeqss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpless( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpltss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpneqss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpnless( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpnltss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpordss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpunordss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpeqss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpless( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpltss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpneqss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpnless( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpnltss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpordss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpunordss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_cvtsi2ss( __v4sf, int ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_cvtsi642ss( __v4sf, long long ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_divss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
@@ -46,18 +46,18 @@ __m128 __builtin_ia32_subss( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0
 __m128 __builtin_ia32_addps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_andnps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_andps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpeqps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpeqps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_cmpgeps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_cmpgtps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpleps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpltps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpneqps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpleps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpltps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpneqps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_cmpngeps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_cmpngtps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpnleps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpnltps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpordps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
-__m128 __builtin_ia32_cmpunordps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpnleps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpnltps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpordps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
+// __m128 __builtin_ia32_cmpunordps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_cvtpi2ps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_divps( __v4sf, __v4sf ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
 __m128 __builtin_ia32_loadhps( __v4sf, const __v2sf * ) { return (__m128){ 0.0f, 0.0f, 0.0f, 0.0f }; }
@@ -105,26 +105,26 @@ __m128d __builtin_ia32_andnsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; 
 __m128d __builtin_ia32_orpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
 __m128d __builtin_ia32_orsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
 __m128d __builtin_ia32_xorpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpltpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpunordsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpnltpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpnlesd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpltpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpunordsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpnltpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpnlesd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
 __m128d __builtin_ia32_cmpgtpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpneqsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpordpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpneqsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpordpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
 __m128d __builtin_ia32_cmpngtpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
 __m128d __builtin_ia32_cmpgepd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpneqpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpordsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpeqpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpneqpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpordsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpeqpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
 __m128d __builtin_ia32_cmpngepd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpnlepd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmplepd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpnltsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpeqsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmplesd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpltsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
-__m128d __builtin_ia32_cmpunordpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpnlepd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmplepd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpnltsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpeqsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmplesd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpltsd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
+// __m128d __builtin_ia32_cmpunordpd( __v2df, __v2df ) { return (__m128d){ 0.0, 0.0 }; }
 __m128i __builtin_ia32_loaddqu( char const * ) { return (__m128i){ 0, 0 }; }
 __m128i __builtin_ia32_movq128( __v2di ) { return (__m128i){ 0, 0 }; }
 int __builtin_ia32_cvttsd2si( __v2df ) { return 0; }
@@ -165,7 +165,7 @@ __m128i __builtin_ia32_pcmpeqd128 ( __v4si, __v4si ) { return (__m128i){ 0, 0 };
 __m128i __builtin_ia32_pcmpgtb128 ( __v16qi, __v16qi ) { return (__m128i){ 0, 0 }; }
 __m128i __builtin_ia32_pcmpgtw128 ( __v8hi, __v8hi ) { return (__m128i){ 0, 0 }; }
 __m128i __builtin_ia32_pcmpgtd128 ( __v4si, __v4si ) { return (__m128i){ 0, 0 }; }
-unsigned char __builtin_ia32_addcarryx_u32( unsigned char, unsigned int, unsigned int, unsigned int * ) { return '\0'; }
+// unsigned char __builtin_ia32_addcarryx_u32( unsigned char, unsigned int, unsigned int, unsigned int * ) { return '\0'; }
 unsigned char __builtin_ia32_addcarryx_u64( unsigned char, unsigned long, unsigned long, unsigned long long * ) { return '\0'; }
 
 #include <errno.h>

--- a/voodoo/gccparity.py
+++ b/voodoo/gccparity.py
@@ -9,7 +9,7 @@ _cachedGCCIncludePath = None
 def gccIncludePath():
     global _cachedGCCIncludePath
     if _cachedGCCIncludePath is None:
-        with open( "/dev/null", "r" ) as noInput:
+        with open( os.devnull, "r" ) as noInput:
             output = subprocess.check_output( [ "cpp", "-Wp,-v" ], stderr = subprocess.STDOUT, stdin = noInput )
-            _cachedGCCIncludePath = re.findall( r"\n (/\S+)", output )
+            _cachedGCCIncludePath = re.findall( r"\n (\S+)", output )
     return _cachedGCCIncludePath

--- a/voodoo/iterateapi.py
+++ b/voodoo/iterateapi.py
@@ -110,7 +110,7 @@ class IterateAPI:
                                                         parameters = parameters,
                                                         returnType = returnType,
                                                         returnRValue = self.__returnRValue( node.result_type ),
-                                                        static = True,
+                                                        static = node.is_static_method(),
                                                         const = False )
             self.functionForwardDeclaration( decomposition = decomposition )
         elif ( node.kind == cindex.CursorKind.FUNCTION_DECL and node.is_definition() or
@@ -125,7 +125,7 @@ class IterateAPI:
                                                                 parameters = parameters,
                                                                 returnType = returnType,
                                                                 returnRValue = self.__returnRValue( node.result_type ),
-                                                                static = True,
+                                                                static = node.is_static_method(),
                                                                 const = False )
             self.functionDefinition( decomposition = decomposition )
         elif ( node.kind == cindex.CursorKind.CONSTRUCTOR or

--- a/voodoo/preprocessor.py
+++ b/voodoo/preprocessor.py
@@ -73,6 +73,9 @@ class Preprocessor:
 		return '\n#endif // __VOODOO_MULTIINCLUDE_PREVENTER_%s__\n' % (
 								self._filenameIdentifier )
 
+	def headerOfHeader( self ):
+		return	( '#include "%s"\n' ) % (	self._pathToOriginal )
+
 	def header( self ):
 		return	(	'%s' +
 					'\n' +

--- a/voodoo/unittests/test_c_parsing.py
+++ b/voodoo/unittests/test_c_parsing.py
@@ -2,15 +2,28 @@ import unittest
 import savingiterator
 import tempfile
 import pprint
+import os
+import platform
 
 class TestCParsing( unittest.TestCase ):
     def setUp( self ):
         self.maxDiff = None
 
     def _tempfile( self, contents ):
-        t = tempfile.NamedTemporaryFile( suffix = ".h" )
+        #
+        # From the python documentation:
+        # Whether the name can be used to open the file a second time, while the
+        # named temporary file is still open, varies across platforms (it can be 
+        # so used on Unix; it cannot  on Windows NT or later).
+        # 
+        if platform.system() == "Windows":
+            t = tempfile.NamedTemporaryFile( suffix = ".h", delete=False )
+        else:
+            t = tempfile.NamedTemporaryFile( suffix = ".h" )
         t.write( contents )
         t.flush()
+        if platform.system() == "Windows":
+          t.close()
         return t
 
     def _simpleTest( self, contents, expected ):
@@ -21,6 +34,8 @@ class TestCParsing( unittest.TestCase ):
             pprint.pprint( tested.saved )
             pprint.pprint( expected )
         self.assertEquals( tested.saved, expected )
+        if platform.system() == "Windows":
+          os.remove( contentsFile.name )
 
     def test_structDeclaration( self ):
         self._simpleTest( "struct name_of_struct;", [ dict( callbackName = "structForwardDeclaration", name = "name_of_struct" ) ] )
@@ -54,50 +69,50 @@ class TestCParsing( unittest.TestCase ):
     def test_globalVoidFunctionForwardDeclaration( self ):
         self._simpleTest( "void aFunction();", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "void aFunction", returnRValue = False, returnType = "void", static = True, const = False, virtual = False ),
+                text = "void aFunction", returnRValue = False, returnType = "void", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalIntFunctionForwardDeclaration( self ):
         self._simpleTest( "int aFunction();", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "int aFunction", returnRValue = False, returnType = "int", static = True, const = False, virtual = False ),
+                text = "int aFunction", returnRValue = False, returnType = "int", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalConstIntFunctionForwardDeclaration( self ):
         self._simpleTest( "const int aFunction();", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "const int aFunction", returnRValue = False, returnType = "const int", static = True, const = False, virtual = False ),
+                text = "const int aFunction", returnRValue = False, returnType = "const int", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalConstCharPFunctionForwardDeclaration( self ):
         self._simpleTest( "const char * aFunction();", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "const char * aFunction", returnRValue = False, returnType = "const char *", static = True, const = False, virtual = False ),
+                text = "const char * aFunction", returnRValue = False, returnType = "const char *", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalConstCharPConstFunctionForwardDeclaration( self ):
         self._simpleTest( "const char * const aFunction();", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "const char * const aFunction", returnRValue = False, returnType = "const char * const", static = True, const = False, virtual = False ),
+                text = "const char * const aFunction", returnRValue = False, returnType = "const char * const", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalUnsignedLongLongFunctionForwardDeclaration( self ):
         self._simpleTest( "unsigned long long aFunction();", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "unsigned long long aFunction", returnRValue = False, returnType = "unsigned long long", static = True, const = False, virtual = False ),
+                text = "unsigned long long aFunction", returnRValue = False, returnType = "unsigned long long", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalVoidFunctionForwardDeclarationIntParameter( self ):
         self._simpleTest( "void aFunction( int a );", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction",
-                text = "void aFunction", returnRValue = False, returnType = "void", static = True, const = False, virtual = False, parameters = [
+                text = "void aFunction", returnRValue = False, returnType = "void", static = False, const = False, virtual = False, parameters = [
                     dict( name = "a", text = "int a", isParameterPack = False ) ] ),
         ] )
 
     def test_globalVoidFunctionForwardDeclarationIntConstCharPParameter( self ):
         self._simpleTest( "void aFunction( int a, const char * p );", [
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "aFunction",
-                text = "void aFunction", returnRValue = False, returnType = "void", static = True, const = False, virtual = False, parameters = [
+                text = "void aFunction", returnRValue = False, returnType = "void", static = False, const = False, virtual = False, parameters = [
                 dict( name = "a", text = "int a", isParameterPack = False ),
                 dict( name = "p", text = "const char * p", isParameterPack = False ), ] ),
         ] )
@@ -120,32 +135,32 @@ class TestCParsing( unittest.TestCase ):
     def test_globalVoidFunctionDefinition( self ):
         self._simpleTest( "void aFunction() {}", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "void aFunction", returnRValue = False, returnType = "void", static = True, const = False, virtual = False ),
+                text = "void aFunction", returnRValue = False, returnType = "void", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalVoidFunctionDefinitionWithInts( self ):
         self._simpleTest( "int aFunction( int a ) { return a; }", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "aFunction", text = "int aFunction",
-                returnRValue = False, returnType = "int", static = True, const = False, virtual = False, parameters = [
+                returnRValue = False, returnType = "int", static = False, const = False, virtual = False, parameters = [
                 dict( name = "a", text = "int a", isParameterPack = False ) ] ),
         ] )
 
     def test_globalVoidFunctionDefinitionStatic( self ):
         self._simpleTest( "static void aFunction() {}", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "void aFunction", returnRValue = False, returnType = "void", static = True, const = False, virtual = False ),
+                text = "void aFunction", returnRValue = False, returnType = "void", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalVoidFunctionDefinitionInline( self ):
         self._simpleTest( "inline void aFunction() {}", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "void aFunction", returnRValue = False, returnType = "void", static = True, const = False, virtual = False ),
+                text = "void aFunction", returnRValue = False, returnType = "void", static = False, const = False, virtual = False ),
         ] )
 
     def test_globalVoidFunctionDefinitionStaticInline( self ):
         self._simpleTest( "static inline void aFunction() {}", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "aFunction", parameters = [],
-                text = "void aFunction", returnRValue = False, returnType = "void", static = True, const = False, virtual = False ),
+                text = "void aFunction", returnRValue = False, returnType = "void", static = False, const = False, virtual = False ),
         ] )
 
     def test_nonEmptyStructDefinition( self ):
@@ -160,7 +175,7 @@ class TestCParsing( unittest.TestCase ):
         self._simpleTest( "const struct S * aFunction( const struct S * s ) { return 0; }", [
             dict( callbackName = 'structForwardDeclaration', name = 'S' ),
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "aFunction",
-                text = "const struct S * aFunction", returnRValue = False, returnType = "const struct S *", static = True, const = False, virtual = False, parameters = [
+                text = "const struct S * aFunction", returnRValue = False, returnType = "const struct S *", static = False, const = False, virtual = False, parameters = [
                 dict( name = "s", text = "const struct S * s", isParameterPack = False ) ] ),
         ] )
 
@@ -222,12 +237,12 @@ extern void dev_put(struct net_device *dev);
             dict( callbackName = "leaveStruct" ),
             dict( callbackName = "variableDeclaration", name = "init_net", text = "extern struct net init_net" ),
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "dev_get_by_name", text = "struct net_device * dev_get_by_name",
-                returnRValue = False, returnType = "struct net_device *", static = True, const = False, virtual = False, parameters = [
+                returnRValue = False, returnType = "struct net_device *", static = False, const = False, virtual = False, parameters = [
                 dict( name = "net", text = "struct net * net", isParameterPack = False ),
                 dict( name = "name", text = "const char * name", isParameterPack = False ) ] ),
             dict( callbackName = 'functionForwardDeclaration', name = 'dev_put',
 		    parameters = [ dict( name = 'dev', text = 'struct net_device * dev', isParameterPack = False ) ],
-                  returnRValue = False, returnType = 'void', static = True, templatePrefix = '', text = 'void dev_put', const = False, virtual = False )
+                  returnRValue = False, returnType = 'void', static = False, templatePrefix = '', text = 'void dev_put', const = False, virtual = False )
         ] )
 
     def test_defines( self ):
@@ -241,11 +256,23 @@ extern void dev_put(struct net_device *dev);
             pprint.pprint( expected )
         self.assertEquals( tested.saved, expected )
 
+    # If the purpose of this test is to validate the redefinition of size_t, it fails with
+	# a 64 bits version of gcc on windows (x86_64-w64-mingw32-c++.exe) with the following error:
+	#   <SourceLocation file 'c:\\cygwin\\distcc\\tmp\\tmpgykt8v.h', line 1, column 23>
+	#   typedef redefinition with different types ('unsigned long' vs 'unsigned int')
+	#   <clang.cindex.RangeIterator instance at 0x0212EC60>
+	#   <clang.cindex.FixItIterator instance at 0x0212EC88>
+	#
+	# If the purpose of this test is to validate that a function can use a typedef'ed type,
+	# size_t can be renamed to eliminate the collision with the system declaration.
+	#
+	# The second possibility is considered the right one as it is easier to address :)
+	# 
     def test_BugfixTypedef1( self ):
-        self._simpleTest( "typedef unsigned long size_t; size_t defunc();", [
-            dict( callbackName = "typedef", name = "size_t", text = "typedef unsigned long size_t" ),
-            dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "defunc", text = "size_t defunc",
-                returnRValue = False, returnType = "size_t", static = True, parameters = [], const = False, virtual = False ),
+        self._simpleTest( "typedef unsigned long a_size_t; a_size_t defunc();", [
+            dict( callbackName = "typedef", name = "a_size_t", text = "typedef unsigned long a_size_t" ),
+            dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "defunc", text = "a_size_t defunc",
+                returnRValue = False, returnType = "a_size_t", static = False, parameters = [], const = False, virtual = False ),
         ] )
 
     def test_StaticVariableShouldNotRemainStaticToAvoidCompilationError( self ):
@@ -256,14 +283,14 @@ extern void dev_put(struct net_device *dev);
         self._simpleTest( "int func() { if ( 1 ) { return 1; } else { return 0; } }", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "func",
                 text = "int func",
-                returnRValue = False, returnType = "int", static = True, parameters = [], const = False, virtual = False ),
+                returnRValue = False, returnType = "int", static = False, parameters = [], const = False, virtual = False ),
         ] )
 
     def test_BugfixHashPoundParsedIntoFunctionDeclarationSyntaticUnit( self ):
         self._simpleTest( "#if 1\nint func() { return 0; }\n#endif", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "func",
                 text = "int func",
-                returnRValue = False, returnType = "int", static = True, parameters = [], const = False, virtual = False ),
+                returnRValue = False, returnType = "int", static = False, parameters = [], const = False, virtual = False ),
         ] )
 
     def test_unionDeclaration( self ):

--- a/voodoo/voodoo.py
+++ b/voodoo/voodoo.py
@@ -46,3 +46,32 @@ def externalVoodoo( input, output, linkTo, pathToRemoveFromIdentifier = "", trac
 	out += "\n}\n\n"
 	out += preprocessor.externalFooter()
 	return out
+
+
+def voodooExpectSource( input, output, pathToRemoveFromIdentifier, voodooDBFile, includes, defines, preIncludes, trace = False ):
+	inputLines = _readLinesOfFile( input )
+	perFileSettings = PerFileSettings( inputLines )
+	preprocessor = Preprocessor( input, output, inputLines, pathToRemoveFromIdentifier )
+
+	iterator = VoodooMultiplexerIterator( perFileSettings, voodooDBFile )
+	iterator.process( input, includes = includes, defines = defines, preIncludes = preIncludes )
+
+	out = preprocessor.headerOfHeader() + '\n'
+	out += '#include "VoodooCommon/All.h"\n\n'
+
+	out += iterator.expect()
+	return out
+
+
+def voodooExpectHeader( input, output, pathToRemoveFromIdentifier, voodooDBFile, includes, defines, preIncludes, trace = False ):
+	inputLines = _readLinesOfFile( input )
+	perFileSettings = PerFileSettings( inputLines )
+	preprocessor = Preprocessor( input, output, inputLines, pathToRemoveFromIdentifier )
+
+	iterator = VoodooMultiplexerIterator( perFileSettings, voodooDBFile )
+	iterator.process( input, includes = includes, defines = defines, preIncludes = preIncludes )
+
+	out = preprocessor.headerOfHeader() + '\n'
+        
+	return out
+


### PR DESCRIPTION
Hi,

I have made some modifications to Voodoo-Mock so I could use it on a Windows
system.

In this document, I detail some of the changes I made, as they range from "I
think I actually fixed something here" to "I have no clue what Im doing, but
it doesnt crash for me".


I was able to demonstrate functionnality with the following setup:
- Microsoft Windows 7 (64bits)
- LLVM version 3.6.0 (only available precompiled in 32 bits)
- Python 2.7.X (32 bits version is required to use the precompiled LLVM)
- The python package: futures 2.2.0
- The python package: clang 3.5
- GnuWin32
- Mingw-w64 (I choose the x86_64-4.9.2-win32-seh-re_v4-rev2)

Also, as our code base is in C, no effort has been made to explore the C++
aspect of Voodoo-Mock in this environment.

And now for a quick presentation of the changes.

cxxtest\cxxtest\PrintStack.h
cxxtest\VoodooConfiguration.h

Modified #if to mildly validate the OS, due to the abscence of sys/wait.h on
Windows.

various makefiles

Adressed various idiosyncrasies. Placed solution in make\common.Makefile wich
is not included in a few more Makefiles.

voodoo\emulate_gcc_in_clang_preinclude.h

I have simply no idea what is happening here!

voodoo\gccparity.py

Filtering of the compiler's include path is done on the "leading space" only
rather than "leading space forward slash". This is tolerant of Windows "[drive
letter]:/path" and "[drive letter]:\\path" formats.

voodoo\iterateapi.py

To allow linkage of mocked function, the mocked function cannot be declared as static.
Instead, rely on the node's information. Probably could be set to "static =
False".

voodoo\multi.py

A non-system specific mecanism of getting the number of cpu's removes the
dependency to extract it from /proc/cpuinfo.

The function voodooOnFileSource allows the creation of a mock as a pair of
header and source file. This allows for linkage of mocked functions with
code generated from C source files.

voodoo\preprocessor.py

When generating mock header and source file, it is presumed that only the
"expect" behavior is desired. The file header represent this.

voodoo\voodoo.py

Basic generators for mock header and source file have been added. They presume
that only the "expect" behavior is desired.

Makefile

As an effort to ensure that the examples are running, bypassing the issue in
example 2 of reimplementing the script env in Windows by calling the Makefile
as in the other examples.