### PR TITLE
Fixed error when method is defined before the class destructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/vf533umpc9rodgwj?svg=true)](https://ci.appveyor.com/project/ShlomiMatichin/voodoo-mock)
+[![wercker status](https://app.wercker.com/status/6319d5b975f2523fdd6baa807c13a91a/m "wercker status")](https://app.wercker.com/project/bykey/6319d5b975f2523fdd6baa807c13a91a)
 
 Voodoo-Mock is a framework for `mock objects' based unit testing in C++.
 Written in python (wrapping over CLang by LLVM project), Voodoo-Mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+futures
+

--- a/voodoo/iterateapi.py
+++ b/voodoo/iterateapi.py
@@ -341,7 +341,8 @@ class IterateAPI:
         if len( tokens ) > 0 and tokens[ -1 ].spelling == terminatorCharacter:
             del tokens[ -1 ]
         if removeOneNonPunctuationTokenFromTheEnd:
-            if len( tokens ) > 0 and tokens[ -1 ].kind != cindex.TokenKind.PUNCTUATION:
+            if len( tokens ) > 0 and \
+                    ( tokens[ -1 ].kind != cindex.TokenKind.PUNCTUATION or tokens[ -1 ].spelling == '~' ):
                 if len( tokens ) >= 2 and tokens[ -2 ].spelling == '=' and \
                         tokens[ -1 ].spelling in [ '0' ]:
                     tokens.pop()

--- a/voodoo/unittests/test_c_parsing.py
+++ b/voodoo/unittests/test_c_parsing.py
@@ -21,7 +21,8 @@ class TestCParsing( unittest.TestCase ):
 
     def test_emptyStructDefinition( self ):
         self._simpleTest( "struct name_of_struct {};", [
-            dict( callbackName = "enterStruct", name = "name_of_struct", fullTextNaked = "structname_of_struct{}", inheritance = [] ),
+            dict( callbackName = "enterStruct", name = "name_of_struct", fullTextNaked = "structname_of_struct{}", inheritance = [],
+                templatePrefix = "", templateParametersList = None ),
             dict( callbackName = "leaveStruct" ),
         ] )
 
@@ -144,7 +145,8 @@ class TestCParsing( unittest.TestCase ):
 
     def test_nonEmptyStructDefinition( self ):
         self._simpleTest( "struct name_of_struct { int a; const char * b; };", [
-            dict( callbackName = "enterStruct", name = "name_of_struct", inheritance = [], fullTextNaked = "structname_of_struct{inta;constchar*b;}" ),
+            dict( callbackName = "enterStruct", name = "name_of_struct", inheritance = [], fullTextNaked = "structname_of_struct{inta;constchar*b;}",
+                templatePrefix = "", templateParametersList = None ),
             dict( callbackName = "fieldDeclaration", name = "a", text = "int a" ),
             dict( callbackName = "fieldDeclaration", name = "b", text = "const char * b" ),
             dict( callbackName = "leaveStruct" ),
@@ -160,7 +162,8 @@ class TestCParsing( unittest.TestCase ):
 
     def test_nonEmptyStructTypdefDefinition( self ):
         self._simpleTest( "typedef struct name_of_struct { int a; const char * b; } struct_t;", [
-            dict( callbackName = "enterStruct", name = "name_of_struct", inheritance = [], fullTextNaked = "structname_of_struct{inta;constchar*b;}" ),
+            dict( callbackName = "enterStruct", name = "name_of_struct", inheritance = [], fullTextNaked = "structname_of_struct{inta;constchar*b;}",
+                templatePrefix = "", templateParametersList = None ),
             dict( callbackName = "fieldDeclaration", name = "a", text = "int a" ),
             dict( callbackName = "fieldDeclaration", name = "b", text = "const char * b" ),
             dict( callbackName = "leaveStruct" ),
@@ -211,9 +214,11 @@ extern struct net init_net;
 extern struct net_device * dev_get_by_name(struct net *net, const char *name);
 extern void dev_put(struct net_device *dev);
         """, [
-            dict( callbackName = "enterStruct", name = 'net_device', inheritance = [], fullTextNaked = "structnet_device{}" ),
+            dict( callbackName = "enterStruct", name = 'net_device', inheritance = [], fullTextNaked = "structnet_device{}",
+                templatePrefix = "", templateParametersList = None ),
             dict( callbackName = "leaveStruct" ),
-            dict( callbackName = "enterStruct", name = 'net', inheritance = [], fullTextNaked = "structnet{}" ),
+            dict( callbackName = "enterStruct", name = 'net', inheritance = [], fullTextNaked = "structnet{}",
+                templatePrefix = "", templateParametersList = None ),
             dict( callbackName = "leaveStruct" ),
             dict( callbackName = "variableDeclaration", name = "init_net", text = "extern struct net init_net" ),
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "dev_get_by_name", text = "struct net_device * dev_get_by_name",
@@ -221,7 +226,7 @@ extern void dev_put(struct net_device *dev);
                 dict( name = "net", text = "struct net * net", isParameterPack = False ),
                 dict( name = "name", text = "const char * name", isParameterPack = False ) ] ),
             dict( callbackName = 'functionForwardDeclaration', name = 'dev_put',
-		    parameters = [ dict( name = 'dev', text = 'struct net_device * dev', isParameterPack = False ) ],
+            parameters = [ dict( name = 'dev', text = 'struct net_device * dev', isParameterPack = False ) ],
                   returnRValue = False, returnType = 'void', static = False, templatePrefix = '', text = 'void dev_put', const = False, virtual = False )
         ] )
 
@@ -268,7 +273,8 @@ extern void dev_put(struct net_device *dev);
 
     def test_anonymousUnionMember( self ):
         self._simpleTest( "struct a { union { int b; int c; } d; };", [
-            dict( callbackName = "enterStruct", name = "a", fullTextNaked = "structa{union{intb;intc;}d;}", inheritance = [] ),
+            dict( callbackName = "enterStruct", name = "a", fullTextNaked = "structa{union{intb;intc;}d;}", inheritance = [],
+                templatePrefix = "", templateParametersList = None ),
             dict( callbackName = "fieldDeclaration", name = "d", text = "union { int b ; int c ; } d" ),
             dict( callbackName = "leaveStruct" ),
         ] )

--- a/voodoo/unittests/test_cpp_parsing.py
+++ b/voodoo/unittests/test_cpp_parsing.py
@@ -442,6 +442,46 @@ class TestCPPParsing( unittest.TestCase ):
             dict( callbackName = "leaveNamespace" ),
         ] )
 
+    def test_templateSpecializationWithEnum( self ):
+        self._simpleTest( "enum class foo { ONE, TWO };template < foo T > struct A {};template <> struct A<foo::ONE> { typedef int * TheType; };", [
+            dict( callbackName = "enum", name = "foo", text = "enum class foo { ONE , TWO }" ),
+            dict( callbackName = "enterStruct", name = "A", inheritance = [],
+                templatePrefix = "template < foo T >", templateParametersList = [ "T" ],
+                fullTextNaked = "template<fooT>structA{}" ),
+            dict( callbackName = "leaveStruct" ),
+            dict( callbackName = "enterStruct", name = "A<foo::ONE>", inheritance = [],
+                templatePrefix = "template <>", templateParametersList = [ "" ],
+                fullTextNaked = "template<>structA<foo::ONE>{typedefint*TheType;}" ),
+            dict( callbackName = "typedef", name = "TheType", text = "typedef int * TheType" ),
+            dict( callbackName = "leaveStruct" ),
+        ] )
+
+    def test_templateSpecializationWithType( self ):
+        self._simpleTest( "template < typename T > struct A {};template <> struct A<int> { typedef int * TheType; };", [
+            dict( callbackName = "enterStruct", name = "A", inheritance = [],
+                templatePrefix = "template < typename T >", templateParametersList = [ "T" ],
+                fullTextNaked = "template<typenameT>structA{}" ),
+            dict( callbackName = "leaveStruct" ),
+            dict( callbackName = "enterStruct", name = "A<int>", inheritance = [],
+                templatePrefix = "template <>", templateParametersList = [ "" ],
+                fullTextNaked = "template<>structA<int>{typedefint*TheType;}" ),
+            dict( callbackName = "typedef", name = "TheType", text = "typedef int * TheType" ),
+            dict( callbackName = "leaveStruct" ),
+        ] )
+
+    def test_templateSpecializationWithIntLiteral( self ):
+        self._simpleTest( "template < int T > struct A {};template <> struct A<5> { typedef int * TheType; };", [
+            dict( callbackName = "enterStruct", name = "A", inheritance = [],
+                templatePrefix = "template < int T >", templateParametersList = [ "T" ],
+                fullTextNaked = "template<intT>structA{}" ),
+            dict( callbackName = "leaveStruct" ),
+            dict( callbackName = "enterStruct", name = "A<5>", inheritance = [],
+                templatePrefix = "template <>", templateParametersList = [ "" ],
+                fullTextNaked = "template<>structA<5>{typedefint*TheType;}" ),
+            dict( callbackName = "typedef", name = "TheType", text = "typedef int * TheType" ),
+            dict( callbackName = "leaveStruct" ),
+        ] )
+
     def test_templateClass( self ):
         self._simpleTest( "template < typename T > class A { T aFunction( T a ) { return 0; }};", [
             dict( callbackName = "enterClass", name = "A", inheritance = [],
@@ -463,19 +503,19 @@ class TestCPPParsing( unittest.TestCase ):
 
     def test_templateStruct( self ):
         self._simpleTest( "template < typename T > struct A { T aFunction( T a ) { return 0; }};", [
-            dict( callbackName = "enterClass", name = "A", inheritance = [],
+            dict( callbackName = "enterStruct", name = "A", inheritance = [],
                 templatePrefix = "template < typename T >", templateParametersList = [ "T" ],
                 fullTextNaked = "template<typenameT>structA{TaFunction(Ta){return0;}}" ),
             dict( callbackName = "method", templatePrefix = "", name = "aFunction",
                 text = "aFunction", returnRValue = False, returnType = "T", static = False, virtual = False, const = False,
                 parameters = [ dict( name = "a", text = "T a", isParameterPack = False ) ] ),
-            dict( callbackName = "leaveClass" ),
+            dict( callbackName = "leaveStruct" ),
         ] )
 
     def test_Bugfix_FunctionsThatReturnClassesMightNeedToReturnRvalue( self ):
         self._simpleTest( "#include <memory>\n"
-                "std::unique_ptr< int > func() { \n"
-                "std::unique_ptr< int > res( new int );\n"
+                    "std::unique_ptr< int > func() { \n"
+                    "std::unique_ptr< int > res( new int );\n"
                 "return std::move( res );}\n", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "func",
                 text = "std :: unique_ptr < int > func",

--- a/voodoo/unittests/test_cpp_parsing.py
+++ b/voodoo/unittests/test_cpp_parsing.py
@@ -275,6 +275,28 @@ class TestCPPParsing( unittest.TestCase ):
             dict( callbackName = "leaveClass" ),
         ] )
 
+    def test_MethodDeclerationBeforeDtor_Bugfix( self ):
+        self._simpleTest( "class File { public: File & operator=( File && rhs ); ~File(); };", [
+            dict( callbackName = "enterClass", name = "File", inheritance = [], templatePrefix = "", templateParametersList = None,
+                fullTextNaked = "classFile{public:File&operator=(File&&rhs);~File();}" ),
+            dict( callbackName = "accessSpec", access = "public" ),
+            dict( callbackName = "method", templatePrefix = "", name = "operator=", text = "operator=",
+                returnRValue = False, returnType = "File &", static = False, virtual = False, const = False, parameters = [
+                    dict( name = "rhs", text = "File && rhs", isParameterPack = False ) ] ),
+            dict( callbackName = "leaveClass" ),
+        ] )
+
+    def test_MethodDefinitionBeforeDtor_Bugfix( self ):
+        self._simpleTest( "class File { public: File & operator=( File && rhs ) { return *this; } ~File() {} };", [
+            dict( callbackName = "enterClass", name = "File", inheritance = [], templatePrefix = "", templateParametersList = None,
+                fullTextNaked = "classFile{public:File&operator=(File&&rhs){return*this;}~File(){}}" ),
+            dict( callbackName = "accessSpec", access = "public" ),
+            dict( callbackName = "method", templatePrefix = "", name = "operator=", text = "operator=",
+                returnRValue = False, returnType = "File &", static = False, virtual = False, const = False, parameters = [
+                    dict( name = "rhs", text = "File && rhs", isParameterPack = False ) ] ),
+            dict( callbackName = "leaveClass" ),
+        ] )
+
     def test_Bugfix_ExplicilyRemoveCommentTokens( self ):
         self._simpleTest( "void /*hello*/ func() /* bye */ {}", [
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "func", text = "void func",

--- a/voodoo/voodooexpectiterator.py
+++ b/voodoo/voodooexpectiterator.py
@@ -35,8 +35,8 @@ class VoodooExpectIterator( VoodooIterator ):
         else:
             self._expect[ -1 ].method( decomposition )
 
-    def enterStruct( self, name, inheritance, fullText ):
-        self._enterConstruct( name, inheritance, "", None, fullText, 'struct', 'public' )
+    def enterStruct( self, name, inheritance, templatePrefix, templateParametersList, fullText ):
+        self._enterConstruct( name, inheritance, templatePrefix, templateParametersList, fullText, 'struct', 'public' )
     def leaveStruct( self ):
         self._leaveConstruct()
     def enterClass( self, name, inheritance, templatePrefix, templateParametersList, fullText ):

--- a/voodoo/voodooiterator.py
+++ b/voodoo/voodooiterator.py
@@ -104,8 +104,8 @@ class VoodooIterator( iterateapi.IterateAPI ):
             mock = self._voodoomocks[ -1 ]
             mock.implementMethod( decomposition )
 
-    def enterStruct( self, name, inheritance, fullText ):
-        self._enterConstruct( name, inheritance, "", None, fullText, 'struct', 'public' )
+    def enterStruct( self, name, inheritance, templatePrefix, templateParametersList, fullText ):
+        self._enterConstruct( name, inheritance, templatePrefix, templateParametersList, fullText, 'struct', 'public' )
     def leaveStruct( self ):
         self._leaveConstruct()
     def enterClass( self, name, inheritance, templatePrefix, templateParametersList, fullText ):

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,26 @@
+box: invalidname/cpp11@0.0.3
+build:
+  steps:
+    - pip-install
+
+    - script:
+        name: Setup gcov
+        code: |
+            sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.8 99
+
+    - script:
+        name: Output versions
+        code: |
+            echo "python version $(python --version)"
+            echo "g++ version $(g++ -v)"
+            echo "gcov version $(gcov -v)"
+
+    - script:
+        name: Voodoo unittest
+        code: |
+            make unittest
+
+    - script:
+        name: Voodoo examples
+        code: |
+            make build


### PR DESCRIPTION
When handlinf a node that represents a method definition/decleration, the last token of the node can be the
first token of the next node.
Until now, __nodeTextTokens handled this by removing the last non-punctuation token.
When the next node represents the destructor, the last token is '~' which is a punctuation type and therefor
it was not stripped.

This parsing error does not always occur in classes because usually the constructors and destructor are
grouped together so its not common to see a method defined/declared right before the destructor.
The parsing of constructors does not depend on __nodeTextTokens stripping the last non-punctuation token.