### PR TITLE
Fixed generation issue with static class members.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clean_examples:
 	make -C examples/3_writing_cpp_tests/custom_stubs clean
 	make -C examples/3_writing_cpp_tests/deriving_a_mocked_interface clean
 	make -C examples/3_writing_cpp_tests/expectation_based_mock_objects clean
+	make -C examples/3_writing_cpp_tests/mocking_class_with_static_member clean
 	make -C examples/6_coverage_enforcement clean
 	make -C examples/7_simple_python_unittest clean
 
@@ -28,4 +29,5 @@ build_examples:
 	make -C examples/3_writing_cpp_tests/custom_stubs
 	make -C examples/3_writing_cpp_tests/deriving_a_mocked_interface
 	make -C examples/3_writing_cpp_tests/expectation_based_mock_objects
+	make -C examples/3_writing_cpp_tests/mocking_class_with_static_member
 	make -C examples/7_simple_python_unittest

--- a/examples/3_writing_cpp_tests/mocking_class_with_static_member/Makefile
+++ b/examples/3_writing_cpp_tests/mocking_class_with_static_member/Makefile
@@ -1,0 +1,17 @@
+all: test
+
+ifeq ($(V),1)
+  Q =
+else
+  Q = @
+endif
+
+export VOODOO_ROOT_DIR=../../..
+export CXXTEST_FIND_ROOT = cpp
+export ENFORCE_COVERAGE_FIND_ROOT_CPP = cpp
+export UNITTEST_INCLUDES = -Ibuild_unittest/voodoo/cpp -Icpp -I.
+export VOODOO_INCLUDES = --includePath=cpp
+
+clean: clean_unittest
+
+include $(VOODOO_ROOT_DIR)/make/integrations/complete.Makefile

--- a/examples/3_writing_cpp_tests/mocking_class_with_static_member/cpp/Example/Mocked.h
+++ b/examples/3_writing_cpp_tests/mocking_class_with_static_member/cpp/Example/Mocked.h
@@ -1,0 +1,57 @@
+#ifndef __MOCKED_H__
+#define __MOCKED_H__
+
+#include <stdio.h>
+
+class FooWithStatic
+{
+public:
+	FooWithStatic()
+	{
+		++_publicInstanceCounter;
+		++_privateInstanceCounter;
+	}
+	void print()
+	{
+		printf( "_publicInstanceCounter: %d, _privateInstanceCounter: %d\n",
+				_publicInstanceCounter, _privateInstanceCounter );
+	}
+
+	static int _publicInstanceCounter;
+private:
+	static int _privateInstanceCounter;
+};
+
+int FooWithStatic::_publicInstanceCounter = 0;
+int FooWithStatic::_privateInstanceCounter = 0;
+
+static int someNum;
+
+class Foo
+{
+public:
+	class IndentedFooWithStatic
+	{
+	public:
+		IndentedFooWithStatic()
+		{
+			++_publicInstanceCounter;
+			++_privateInstanceCounter;
+		}
+		void print()
+		{
+			printf( "_publicInstanceCounter: %d, _privateInstanceCounter: %d\n",
+					_publicInstanceCounter, _privateInstanceCounter );
+		}
+
+		static int _publicInstanceCounter;
+	private:
+		static int _privateInstanceCounter;
+	};
+};
+
+int Foo::IndentedFooWithStatic::_publicInstanceCounter = 0;
+int Foo::IndentedFooWithStatic::_privateInstanceCounter = 0;
+
+#endif // __MOCKED_H__
+// FILE_EXEMPT_FROM_CODE_COVERAGE

--- a/examples/3_writing_cpp_tests/mocking_class_with_static_member/cpp/Example/UnderTest.h
+++ b/examples/3_writing_cpp_tests/mocking_class_with_static_member/cpp/Example/UnderTest.h
@@ -1,0 +1,14 @@
+#ifndef __UNDERTEST_H_
+#define __UNDERTEST_H_
+
+#include "Mocked.h"
+#include <memory>
+
+void printFoo()
+{
+	FooWithStatic f;
+	f.print();
+}
+
+#endif // __UNDERTEST_H_
+// FILE_EXEMPT_FROM_CODE_COVERAGE

--- a/examples/3_writing_cpp_tests/mocking_class_with_static_member/cpp/Example/tests/Test_UnderTest.h
+++ b/examples/3_writing_cpp_tests/mocking_class_with_static_member/cpp/Example/tests/Test_UnderTest.h
@@ -1,0 +1,34 @@
+#include <cxxtest/TestSuite.h>
+#define VOODOO_EXPECT_cpp_Example_Mocked_h
+
+#include "Example/UnderTest.h"
+
+using namespace VoodooCommon::Expect;
+using namespace VoodooCommon::Expect::Parameter;
+
+class Test_Example: public CxxTest::TestSuite
+{
+public:
+	class TestFailed {};
+
+	void setUp()
+	{
+	}
+
+	void tearDown()
+	{
+	}
+
+	void test_printFoo()
+	{
+		Scenario scenario;
+		scenario <<
+			new Construction< FooWithStatic >( "foo" ) <<
+			new CallReturnVoid( "foo::print" ) <<
+			new Destruction( "foo" );
+
+		printFoo();
+
+		scenario.assertFinished();
+	}
+};

--- a/voodoo/iterateapi.py
+++ b/voodoo/iterateapi.py
@@ -18,7 +18,7 @@ class IterateAPI:
     def leaveStruct( self ): assert False, "Please override in deriving class"
     def enterClass( self, name, inheritance, templatePrefix, templateParametersList, fullText ): assert False, "Please override in deriving class"
     def leaveClass( self ): assert False, "Please override in deriving class"
-    def variableDeclaration( self, name, text ): assert False, "Please override in deriving class"
+    def variableDeclaration( self, name, fullyQualifiedName, static, text ): assert False, "Please override in deriving class"
     def typedef( self, name, text ): assert False, "Please override in deriving class"
     def union( self, name, text ): assert False, "Please override in deriving class"
     def enum( self, name, text ): assert False, "Please override in deriving class"
@@ -115,10 +115,14 @@ class IterateAPI:
             for child in node.get_children():
                 self.__iterateNode( child )
         elif node.kind == cindex.CursorKind.VAR_DECL:
-            if "static constexpr" in self.__nodeText( node ):
-                self.variableDeclaration( name = node.spelling, text = self.__nodeText( node ) )
+            nodeText = self.__nodeText( node )
+            if "static constexpr" in nodeText:
+                self.variableDeclaration( name = node.spelling, fullyQualifiedName = node.get_usr(),
+                    static = False, text = nodeText )
             else:
-                self.variableDeclaration( name = node.spelling, text = self.__nodeText( node, removePrefixKeywords = [ 'static' ] ) )
+                self.variableDeclaration( name = node.spelling, fullyQualifiedName = node.get_usr(),
+                        static = "static" in nodeText,
+                        text = self.__nodeText( node, removePrefixKeywords = [ 'static' ] ) )
         elif node.kind == cindex.CursorKind.FIELD_DECL:
             self.fieldDeclaration( name = node.spelling, text = self.__nodeText( node ) )
         elif node.kind == cindex.CursorKind.TYPEDEF_DECL:

--- a/voodoo/unittests/savingiterator.py
+++ b/voodoo/unittests/savingiterator.py
@@ -32,6 +32,8 @@ class SavingIterator( iterateapi.IterateAPI ):
         setattr( self, callName, lambda decomposition: self._save( callName, ** decomposition.__dict__ ) )
 
     def _save( self, callbackName, fullText = None, ** kwargs ):
+        if 'fullyQualifiedName' in kwargs:
+            del kwargs[ 'fullyQualifiedName' ]
         if fullText is not None:
             kwargs[ 'fullTextNaked' ] = fullText.strip( ';' ).replace( " ", "" ).replace( "\t", "" ).replace( '\n', '' )
         self.saved.append( dict( callbackName = callbackName, ** kwargs ) )

--- a/voodoo/unittests/test_c_parsing.py
+++ b/voodoo/unittests/test_c_parsing.py
@@ -28,17 +28,17 @@ class TestCParsing( unittest.TestCase ):
 
     def test_globalInteger( self ):
         self._simpleTest( "int global;", [
-            dict( callbackName = "variableDeclaration", name = "global", text = "int global" ),
+            dict( callbackName = "variableDeclaration", name = "global", static = False, text = "int global" ),
         ] )
 
     def test_globalPointer( self ):
         self._simpleTest( "char * global;", [
-            dict( callbackName = "variableDeclaration", name = "global", text = "char * global" ),
+            dict( callbackName = "variableDeclaration", name = "global", static = False, text = "char * global" ),
         ] )
 
     def test_globalConstPointer( self ):
         self._simpleTest( "const char * global;", [
-            dict( callbackName = "variableDeclaration", name = "global", text = "const char * global" ),
+            dict( callbackName = "variableDeclaration", name = "global", static = False, text = "const char * global" ),
         ] )
 
     def test_globalTypedef( self ):
@@ -99,7 +99,7 @@ class TestCParsing( unittest.TestCase ):
 
     def test_VoidFunctionPointerDefinition( self ):
         self._simpleTest( "void (*aFunction)();", [
-            dict( callbackName = "variableDeclaration", name = "aFunction", text = "void ( * aFunction ) ( )" ),
+            dict( callbackName = "variableDeclaration", name = "aFunction", static = False, text = "void ( * aFunction ) ( )" ),
         ] )
 
     def test_TypedefVoidFunctionPointerDefinition( self ):
@@ -173,7 +173,7 @@ class TestCParsing( unittest.TestCase ):
     def test_useTypedef( self ):
         self._simpleTest( "typedef int Int;\nInt i;", [
             dict( callbackName = "typedef", name = "Int", text = "typedef int Int" ),
-            dict( callbackName = "variableDeclaration", name = "i", text = "Int i" ),
+            dict( callbackName = "variableDeclaration", name = "i", static = False, text = "Int i" ),
         ] )
 
     def _parseError( self, contents ):
@@ -203,7 +203,7 @@ class TestCParsing( unittest.TestCase ):
 
     def test_includeScenario( self ):
         self._testInclude( "typedef int Int;", "Int i;", [
-            dict( callbackName = "variableDeclaration", name = "i", text = "Int i" ),
+            dict( callbackName = "variableDeclaration", name = "i", static = False, text = "Int i" ),
         ] )
 
     def test_realCase( self ):
@@ -220,7 +220,7 @@ extern void dev_put(struct net_device *dev);
             dict( callbackName = "enterStruct", name = 'net', inheritance = [], fullTextNaked = "structnet{}",
                 templatePrefix = "", templateParametersList = None ),
             dict( callbackName = "leaveStruct" ),
-            dict( callbackName = "variableDeclaration", name = "init_net", text = "extern struct net init_net" ),
+            dict( callbackName = "variableDeclaration", name = "init_net", static = False, text = "extern struct net init_net" ),
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "dev_get_by_name", text = "struct net_device * dev_get_by_name",
                 returnRValue = False, returnType = "struct net_device *", static = False, const = False, virtual = False, parameters = [
                 dict( name = "net", text = "struct net * net", isParameterPack = False ),
@@ -250,7 +250,7 @@ extern void dev_put(struct net_device *dev);
 
     def test_StaticVariableShouldNotRemainStaticToAvoidCompilationError( self ):
         self._simpleTest( "static int i;", [
-            dict( callbackName = "variableDeclaration", name = "i", text = "int i" ) ] )
+            dict( callbackName = "variableDeclaration", name = "i", static = True, text = "int i" ) ] )
 
     def test_BugfixRecursiveBraces( self ):
         self._simpleTest( "int func() { if ( 1 ) { return 1; } else { return 0; } }", [
@@ -283,16 +283,16 @@ extern void dev_put(struct net_device *dev);
         self._simpleTest( "#define nothing nada\n", [] )
         self._simpleTest( "#define nothing\n\nnothing", [] )
         self._simpleTest( "#define nothing\n\nnothing int a;", [
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = False, text = "int a" ),
         ] )
         self._simpleTest( "#define a b\n\nint a;", [
-            dict( callbackName = "variableDeclaration", name = "b", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "b", static = False, text = "int a" ),
         ] )
 
     def notest_KnownIssue_DefiningIntBoolOrBuiltinTypes( self ):
         self._simpleTest( "#define int int\n\rbool b;\nint a;", [
-            dict( callbackName = "variableDeclaration", name = "b", text = "bool b" ),
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "b", static = False, text = "bool b" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = False, text = "int a" ),
         ] )
 
 if __name__ == '__main__':

--- a/voodoo/unittests/test_cpp_parsing.py
+++ b/voodoo/unittests/test_cpp_parsing.py
@@ -29,6 +29,36 @@ class TestCPPParsing( unittest.TestCase ):
             pprint.pprint( expected )
         self.assertEquals( tested.saved, expected )
 
+    def test_staticMemberDecleration( self ):
+        self._simpleTest( "class SuperDuper { static int y; public: static int x; private: int z; }; int SuperDuper::y;", [
+            dict( callbackName = "enterClass", name = "SuperDuper", inheritance = [],
+                templatePrefix = "", templateParametersList = None, fullTextNaked = "classSuperDuper{staticinty;public:staticintx;private:intz;}" ),
+            dict( callbackName = "variableDeclaration", name = "y", static = True, text = "int y" ),
+            dict( callbackName = "accessSpec", access = "public" ),
+            dict( callbackName = "variableDeclaration", name = "x", static = True, text = "int x" ),
+            dict( callbackName = "accessSpec", access = "private" ),
+            dict( callbackName = "fieldDeclaration", name = "z", text = "int z" ),
+            dict( callbackName = "leaveClass" ),
+            dict( callbackName = "variableDeclaration", name = "y", static = False, text = "int SuperDuper :: y" ),
+        ] )
+
+    def test_staticMemberDeclerationForIndentedClass( self ):
+        self._simpleTest( "class Super { public: class SuperDuper { static int y; public: static int x; private: int z; };}; int Super::SuperDuper::y;", [
+            dict( callbackName = "enterClass", name = "Super", inheritance = [],
+                templatePrefix = "", templateParametersList = None, fullTextNaked = "classSuper{public:classSuperDuper{staticinty;public:staticintx;private:intz;};}" ),
+            dict( callbackName = "accessSpec", access = "public" ),
+            dict( callbackName = "enterClass", name = "SuperDuper", inheritance = [],
+                templatePrefix = "", templateParametersList = None, fullTextNaked = "classSuperDuper{staticinty;public:staticintx;private:intz;}" ),
+            dict( callbackName = "variableDeclaration", name = "y", static = True, text = "int y" ),
+            dict( callbackName = "accessSpec", access = "public" ),
+            dict( callbackName = "variableDeclaration", name = "x", static = True, text = "int x" ),
+            dict( callbackName = "accessSpec", access = "private" ),
+            dict( callbackName = "fieldDeclaration", name = "z", text = "int z" ),
+            dict( callbackName = "leaveClass" ),
+            dict( callbackName = "leaveClass" ),
+            dict( callbackName = "variableDeclaration", name = "y", static = False, text = "int Super :: SuperDuper :: y" ),
+        ] )
+
     def test_classDeclaration( self ):
         self._simpleTest( "class SuperDuper { int y; public: int x; private: int z; };", [
             dict( callbackName = "enterClass", name = "SuperDuper", inheritance = [],
@@ -45,12 +75,12 @@ class TestCPPParsing( unittest.TestCase ):
         self._simpleTest( "namespace A { namespace B { int b; } namespace C { int c; } int a; }", [
             dict( callbackName = "enterNamespace", name = "A" ),
             dict( callbackName = "enterNamespace", name = "B" ),
-            dict( callbackName = "variableDeclaration", name = "b", text = "int b" ),
+            dict( callbackName = "variableDeclaration", name = "b", static = False, text = "int b" ),
             dict( callbackName = "leaveNamespace" ),
             dict( callbackName = "enterNamespace", name = "C" ),
-            dict( callbackName = "variableDeclaration", name = "c", text = "int c" ),
+            dict( callbackName = "variableDeclaration", name = "c", static = False, text = "int c" ),
             dict( callbackName = "leaveNamespace" ),
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = False, text = "int a" ),
             dict( callbackName = "leaveNamespace" ),
         ] )
 
@@ -71,12 +101,12 @@ class TestCPPParsing( unittest.TestCase ):
         self._simpleTest( "namespace A { namespace B { int b; } namespace C { int c; } int a; } namespace D = A::B;", [
             dict( callbackName = "enterNamespace", name = "A" ),
             dict( callbackName = "enterNamespace", name = "B" ),
-            dict( callbackName = "variableDeclaration", name = "b", text = "int b" ),
+            dict( callbackName = "variableDeclaration", name = "b", static = False, text = "int b" ),
             dict( callbackName = "leaveNamespace" ),
             dict( callbackName = "enterNamespace", name = "C" ),
-            dict( callbackName = "variableDeclaration", name = "c", text = "int c" ),
+            dict( callbackName = "variableDeclaration", name = "c", static = False, text = "int c" ),
             dict( callbackName = "leaveNamespace" ),
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = False, text = "int a" ),
             dict( callbackName = "leaveNamespace" ),
         dict( callbackName = "using", text = "namespace D = A :: B" ),
         ] )
@@ -217,7 +247,7 @@ class TestCPPParsing( unittest.TestCase ):
             dict( callbackName = "enterClass", name = "Result", inheritance = [], templatePrefix = "", templateParametersList = None,
                 fullTextNaked = "classResult{}" ),
             dict( callbackName = "leaveClass" ),
-            dict( callbackName = "variableDeclaration", name = "globalResult", text = "Result globalResult" ),
+            dict( callbackName = "variableDeclaration", name = "globalResult", static = False, text = "Result globalResult" ),
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "getResult", text = "Result & getResult",
                 returnRValue = False, returnType = "Result &", static = False, virtual = False, const = False, parameters = [] ),
         ] )
@@ -227,7 +257,7 @@ class TestCPPParsing( unittest.TestCase ):
             dict( callbackName = "enterClass", name = "Result", inheritance = [], templatePrefix = "", templateParametersList = None,
                 fullTextNaked = "classResult{}" ),
             dict( callbackName = "leaveClass" ),
-            dict( callbackName = "variableDeclaration", name = "globalResult", text = "Result globalResult" ),
+            dict( callbackName = "variableDeclaration", name = "globalResult", static = False, text = "Result globalResult" ),
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "getResult", text = "const Result & getResult",
                 returnRValue = False, returnType = "const Result &", static = False, virtual = False, const = False, parameters = [] ),
         ] )
@@ -237,7 +267,7 @@ class TestCPPParsing( unittest.TestCase ):
             dict( callbackName = "enterClass", name = "Result", inheritance = [], templatePrefix = "", templateParametersList = None,
                 fullTextNaked = "classResult{}" ),
             dict( callbackName = "leaveClass" ),
-            dict( callbackName = "variableDeclaration", name = "globalResult", text = "Result globalResult" ),
+            dict( callbackName = "variableDeclaration", name = "globalResult", static = False, text = "Result globalResult" ),
             dict( callbackName = "functionDefinition", templatePrefix = "", name = "getResult", text = "Result * getResult",
                 returnRValue = False, returnType = "Result *", static = False, virtual = False, const = False, parameters = [] ),
         ] )
@@ -348,7 +378,7 @@ class TestCPPParsing( unittest.TestCase ):
                 fullTextNaked = "classAInterface{virtualintf()const=0;staticinta;}" ),
             dict( callbackName = "method", templatePrefix = "", name = "f", text = "f",
                 returnRValue = False, returnType = "int", static = False, virtual = True, const = True, parameters = [] ),
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = True, text = "int a" ),
             dict( callbackName = "leaveClass" ),
             dict( callbackName = "enterClass", name = "B", inheritance = [ ( 'public', 'AInterface' ) ],
                 templatePrefix = "", templateParametersList = None, fullTextNaked = "classB:publicAInterface{intf()constoverride{return0;}}" ),
@@ -376,7 +406,7 @@ class TestCPPParsing( unittest.TestCase ):
 
     def test_ExternC( self ):
         self._simpleTest( 'extern "C" { int a; }\nextern "C" void f();', [
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = False, text = "int a" ),
             dict( callbackName = "functionForwardDeclaration", templatePrefix = "", name = "f", text = "void f",
                 returnRValue = False, returnType = "void", static = False, virtual = False, const = False, parameters = [] ),
         ] )
@@ -392,7 +422,7 @@ class TestCPPParsing( unittest.TestCase ):
 
 #    def test_CodeInMacro( self ):
 #        self._simpleTest( "#define X class SuperDuper { public: int aFunction( int a ) { return 0; } int c; }\nint c; X;", [
-#            dict( callbackName = "variableDeclaration", name = "c", text = "int c" ),
+#            dict( callbackName = "variableDeclaration", name = "c", static = False, text = "int c" ),
 #            dict( callbackName = "enterClass", name = "SuperDuper", inheritance = [], templatePrefix = "", templateParametersList = None,
 #                fullTextNaked = "classSuperDuper{public:intaFunction(inta){return0;}intc;}" ),
 #            dict( callbackName = "accessSpec", access = "public" ),
@@ -436,7 +466,7 @@ class TestCPPParsing( unittest.TestCase ):
                 fullTextNaked = "classAInterface{virtualintf()=0;staticinta;}" ),
             dict( callbackName = "method", templatePrefix = "", name = "f", text = "f",
                 returnRValue = False, returnType = "int", static = False, virtual = True, const = False, parameters = [] ),
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = True, text = "int a" ),
             dict( callbackName = "leaveClass" ),
             dict( callbackName = "enterClass", name = "B", inheritance = [ ( 'public', 'AInterface' ) ],
                 templatePrefix = "", templateParametersList = None, fullTextNaked = "classB:publicAInterface{intf()overridefinal{return0;}}" ),
@@ -448,7 +478,7 @@ class TestCPPParsing( unittest.TestCase ):
     def test_usingNotANamespace( self ):
         self._simpleTest( "namespace A { int a; } namespace B { using A::a; }", [
             dict( callbackName = "enterNamespace", name = "A" ),
-            dict( callbackName = "variableDeclaration", name = "a", text = "int a" ),
+            dict( callbackName = "variableDeclaration", name = "a", static = False, text = "int a" ),
             dict( callbackName = "leaveNamespace" ),
             dict( callbackName = "enterNamespace", name = "B" ),
             dict( callbackName = "using", text = "using A :: a" ),


### PR DESCRIPTION
Now voodoo will generate both decleration and definition for static class members which are not private and
are not marked to be ignored.

When a static class member is ignored, both its definition and decleration are ignored.